### PR TITLE
Adjust mobile controls positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,6 +123,11 @@
   /* Gamepad接続時は仮想UIを半透明化（自動縮退） */
   .gamepad .virtual { opacity: .25; }
 
+  @media (orientation: landscape) and (pointer: coarse) {
+    .stick { transform: translateX(-3cm); }
+    .buttons { transform: translateX(3cm); }
+  }
+
   /* ===== ダイアログ（<dialog>） ===== */
   dialog { border: none; padding: 0; background: transparent; }
   .sheet { width: min(92vw, 480px); background: rgba(18,20,28,0.9); backdrop-filter: blur(8px); border: 1px solid var(--outline); color: var(--text); border-radius: 16px; overflow: hidden; }


### PR DESCRIPTION
## Summary
- shift virtual joystick 3cm left and action buttons 3cm right when using a mobile device in landscape mode

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3eefead9c83309057b36f3a0627c1